### PR TITLE
算法数据集的默认选项 & 自动化runbook迁移至congestion 

### DIFF
--- a/benchmark/algorithms/definitions.py
+++ b/benchmark/algorithms/definitions.py
@@ -116,6 +116,9 @@ def get_definitions(definition_file, dimension, dataset,
         algorithm_definitions.update(definitions["any"])
     if dataset in definitions:
         algorithm_definitions.update(definitions[dataset])
+    # Default
+    if not algorithm_definitions:
+        algorithm_definitions.update(definitions["random-xs"])
 
     definitions = []
     for (name, algo) in algorithm_definitions.items():

--- a/benchmark/datasets.py
+++ b/benchmark/datasets.py
@@ -1505,9 +1505,12 @@ class REDDIT(DatasetCompetitionFormat):
 
         prepocessflag = 0
         if prepocessflag == 0:
-            num, dim, vectors = load_data(self.basedir + '/data_100000_768')
-            index_vectors, query_vectors = sample_vectors(vectors, self.nb, self.nq)
+            num, dim, vectors = load_data(self.basedir+'/data_100000_768')
+            index_vectors, _ = sample_vectors(vectors, self.nb, self.nq)
             save_data(index_vectors, type='data', basedir=self.basedir)
+
+            num, dim, vectors = load_data(self.basedir+'/queries_2000_768')
+            _, query_vectors = sample_vectors(vectors, 0, self.nq)
             save_data(query_vectors, type='queries', basedir=self.basedir)
 
     def search_type(self):

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -168,8 +168,23 @@ def main():
         help='runbook yaml path for neurips23 streaming track',
         default='neurips23/streaming/simple_runbook.yaml'
     )
+    parser.add_argument(
+        '--eventrate',
+        type=int,
+        help='Event rate for congestion scenarios'
+    )
+    parser.add_argument(
+        '--batchsize',
+        type=int,
+        help='Batch size for congestion scenarios'
+    )
 
     args = parser.parse_args()
+
+    # if args.neurips23track == 'congestion':
+    #     if args.eventrate is None or args.batchsize is None:
+    #         raise ValueError("Both --eventrate and --batchsize must be provided when --neurips23track is 'congestion'.")
+
     if args.timeout == -1:
         args.timeout = None
 

--- a/benchmark/random_datasets_utils.py
+++ b/benchmark/random_datasets_utils.py
@@ -1,3 +1,5 @@
+from smtplib import quotedata
+
 from benchmark.datasets import DATASETS, RandomDS, RandomRangeDS, RandomPlus
 import re
 import os
@@ -10,6 +12,10 @@ def normalize_dataset_name(dataset_name):
 def parse_dataset(args):
     if args.dataset in DATASETS:
         dataset = DATASETS[args.dataset]()
+
+        streaming_runbook_file, congestion_runbook_file = get_runbook_paths(args)
+        update_runbook_for_dataset(args, dataset.nb, streaming_runbook_file, congestion_runbook_file)
+
         return dataset
 
     elif args.dataset.startswith("random-plus"):
@@ -36,10 +42,11 @@ def custom_random_plus(args):
         query_noise_fraction = float(match.group(7)) if match.group(7) else 0
         basedir = match.group(8) if match.group(8) else "randomplus"
         add_dataset(dataset_name, f'RandomPlus({nb}, {nq}, {d}, {seed}, {drift_position}, {drift_offset}, {query_noise_fraction}, "{basedir}")')
-        if hasattr(args, 'runbook_path'):
-            generate_runbook_yaml(dataset_name, nb, args.runbook_path)
-        else:
-            generate_runbook_yaml(dataset_name, nb, 'neurips23/runbooks/simple_runbook.yaml')
+        DATASETS[dataset_name] = lambda : RandomPlus(nb, nq, d, seed, drift_position, drift_offset, query_noise_fraction, basedir)
+
+        streaming_runbook_file, congestion_runbook_file = get_runbook_paths(args)
+        update_runbook_for_dataset(args, nb, streaming_runbook_file, congestion_runbook_file)
+
         return RandomPlus(nb, nq, d, seed, drift_position, drift_offset, query_noise_fraction, basedir)
     else:
         raise ValueError(f"Invalid dataset format: {dataset_name}")
@@ -52,10 +59,11 @@ def custom_random_ds(args):
         nb, nq, d = map(int, match.groups()[1:4])
         basedir = match.group(5) if match.group(5) else "random"
         add_dataset(dataset_name, f'RandomDS({nb}, {nq}, {d}, "{basedir}")')
-        if hasattr(args, 'runbook_path'):
-            generate_runbook_yaml(dataset_name, nb, args.runbook_path)
-        else:
-            generate_runbook_yaml(dataset_name, nb, 'neurips23/runbooks/simple_runbook.yaml')
+        DATASETS[dataset_name] = lambda: RandomDS(nb, nq, d, basedir)
+
+        streaming_runbook_file, congestion_runbook_file = get_runbook_paths(args)
+        update_runbook_for_dataset(args, nb, streaming_runbook_file, congestion_runbook_file)
+
         return RandomDS(nb, nq, d, basedir)
     else:
         raise ValueError(f"Invalid dataset format for random-xs or random-s: {dataset_name}")
@@ -67,10 +75,11 @@ def custom_random_range_ds(args):
     if match:
         nb, nq, d = map(int, match.groups()[1:4])
         add_dataset(dataset_name, f'RandomRangeDS({nb}, {nq}, {d})')
-        if hasattr(args, 'runbook_path'):
-            generate_runbook_yaml(dataset_name, nb, args.runbook_path)
-        else:
-            generate_runbook_yaml(dataset_name, nb, 'neurips23/runbooks/simple_runbook.yaml')
+        DATASETS[dataset_name] = lambda: RandomRangeDS(nb, nq, d)
+
+        streaming_runbook_file, congestion_runbook_file = get_runbook_paths(args)
+        update_runbook_for_dataset(args, nb, streaming_runbook_file, congestion_runbook_file)
+
         return RandomRangeDS(nb, nq, d)
     else:
         raise ValueError(f"Invalid dataset format for random-range-xs or random-range-s: {dataset_name}")
@@ -99,27 +108,147 @@ def add_dataset(dataset_name, dataset_func, file_path='benchmark/datasets.py'):
     print(f"Successfully added {dataset_name} to {file_path}")
 
 
-def generate_runbook_yaml(dataset, max_pts, runbook_file):
-    if os.path.exists(runbook_file):
-        with open(runbook_file, "r") as f:
-            runbook_content = yaml.safe_load(f) or {}
-    else:
-        runbook_content = {}
+def generate_Streaming_runbook_yaml(dataset, max_pts, runbook_file='neurips23/runbooks/streaming/simple_runbook.yaml'):
+
+    def custom_operation_representer(dumper, value):
+        quoted_operations = ["insert", "search", "delete", "none"]
+        if value in quoted_operations:
+            return dumper.represent_scalar('tag:yaml.org,2002:str', value, style='"')
+        else:
+            return dumper.represent_scalar('tag:yaml.org,2002:str', value)
+
+    yaml.add_representer(str, custom_operation_representer)
 
     dataset_info = {
         "max_pts": max_pts,
-        1: {"operation": "insert", "start": 0, "end": max_pts},
+        1: {"operation": "insert",
+            "start": 0,
+            "end": max_pts
+        },
         2: {"operation": "search"},
-        3: {"operation": "delete", "start": 0, "end": max_pts // 2},
+        3: {"operation": "delete",
+            "start": 0,
+            "end": max_pts // 2
+        },
         4: {"operation": "search"},
-        5: {"operation": "insert", "start": 0, "end": max_pts // 2},
+        5: {"operation": "insert",
+            "start": 0,
+            "end": max_pts // 2
+        },
         6: {"operation": "search"},
-        "gt_url": "https://comp21storage.z5.web.core.windows.net/comp23/str_gt/random10000/10000/simple_runbook.yaml"
+        "gt_url": "none"
     }
 
-    runbook_content[dataset] = dataset_info
-    print(runbook_file)
-    with open(runbook_file, "w") as f:
-        yaml.dump(runbook_content, f, default_flow_style=False, sort_keys=False)
+    with open(runbook_file, "a") as f:
+        f.write("\n")
+        yaml.dump({dataset: dataset_info}, f, default_flow_style=False, sort_keys=False)
 
-    print(f"Runbook updated successfully for dataset: {dataset}")
+    print(f"Streaming Runbook updated successfully for dataset: {dataset}")
+
+
+def generate_congestion_runbook_yaml(dataset, max_pts, runbook_file, batch_size, event_rate):
+
+    def custom_operation_representer(dumper, value):
+        quoted_operations = ["search", "startHPC", "initial", "batch_insert", "waitPending", "delete", "endHPC", "none"]
+        if value in quoted_operations:
+            return dumper.represent_scalar('tag:yaml.org,2002:str', value, style='"')
+        else:
+            return dumper.represent_scalar('tag:yaml.org,2002:str', value)
+
+    yaml.add_representer(str, custom_operation_representer)
+
+    dataset_info = {
+        "max_pts": max_pts,
+        1: {"operation": "startHPC"},
+        2: {"operation": "initial",
+            "start": 0,
+            "end": 5000
+        },
+        3: {
+            "operation": "batch_insert",
+            "start": 5000,
+            "end": max_pts,
+            "batchSize": batch_size,
+            "eventRate": event_rate,
+        },
+        4: {"operation": "search"},
+        5: {"operation": "waitPending"},
+        6: {"operation": "delete",
+            "start": 0,
+            "end": max_pts // 2
+        },
+        7: {"operation": "waitPending"},
+        8: {"operation": "search"},
+        9: {
+            "operation": "batch_insert",
+            "start": 0,
+            "end": max_pts // 2,
+            "batchSize": batch_size,
+            "eventRate": event_rate,
+        },
+        10: {"operation": "waitPending"},
+        11: {"operation": "search"},
+        12: {"operation": "endHPC"},
+        "gt_url": "none",
+    }
+
+    with open(runbook_file, "a") as f:
+        f.write("\n")
+        yaml.dump({dataset: dataset_info}, f, default_flow_style=False, sort_keys=False)
+
+    print(f"Congestion Runbook updated successfully for dataset: {dataset}")
+
+
+def read_runbook(runbook_file):
+    try:
+        with open(runbook_file, 'r') as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def is_dataset_in_runbook(runbook_data, dataset):
+    return dataset in runbook_data
+
+
+def update_streaming_runbook(dataset, max_pts, runbook_file):
+    runbook_data = read_runbook(runbook_file)
+
+    if is_dataset_in_runbook(runbook_data, dataset):
+        print(f"Dataset '{dataset}' already exists in the streaming runbook.")
+    else:
+        generate_Streaming_runbook_yaml(dataset, max_pts, runbook_file)
+
+
+def update_congestion_runbook(dataset, max_pts, runbook_file, batch_size, event_rate):
+    runbook_data = read_runbook(runbook_file)
+
+    if is_dataset_in_runbook(runbook_data, dataset):
+        print(f"Dataset '{dataset}' already exists in the congestion runbook.")
+    else:
+        generate_congestion_runbook_yaml(dataset, max_pts, runbook_file, batch_size, event_rate)
+
+def update_runbook_for_dataset(args,
+                               max_pts,
+                               streaming_runbook_file='neurips23/runbooks/streaming/simple_runbook.yaml',
+                               congestion_runbook_file='neurips23/runbooks/congestion/simple_runbook.yaml',):
+    update_streaming_runbook(args.dataset, max_pts, streaming_runbook_file)
+
+    if args.batchsize is not None and args.eventrate is not None:
+        if hasattr(args, 'neurips23track'):
+            if args.neurips23track == 'congestion':
+                update_congestion_runbook(args.dataset, max_pts, congestion_runbook_file, args.batchsize, args.eventrate)
+        else:
+            update_congestion_runbook(args.dataset, max_pts, congestion_runbook_file, args.batchsize, args.eventrate)
+
+def get_runbook_paths(args):
+    default_streaming_path = 'neurips23/runbooks/streaming/simple_runbook.yaml'
+    default_congestion_path = 'neurips23/runbooks/congestion/simple_runbook.yaml'
+
+    if hasattr(args, 'runbook_path'):
+        if args.neurips23track == 'congestion':
+            return default_streaming_path, args.runbook_path
+        else:
+            return args.runbook_path, default_congestion_path
+    else:
+        return default_streaming_path, default_congestion_path

--- a/create_dataset.py
+++ b/create_dataset.py
@@ -12,6 +12,17 @@ if __name__ == "__main__":
         '--skip-data',
         action='store_true',
         help='skip downloading base vectors')
+    parser.add_argument(
+        '--eventrate',
+        type=int,
+        help='Event rate for congestion scenarios'
+    )
+    parser.add_argument(
+        '--batchsize',
+        type=int,
+        help='Batch size for congestion scenarios'
+    )
+
     args = parser.parse_args()
     ds = parse_dataset(args)
     ds.prepare(True if args.skip_data else False)

--- a/data_export.py
+++ b/data_export.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
     neurips23tracks = ['streaming', 'none', 'congestion']
     tracks = [args.track]
     is_first = True
-    datasets = ['random-xs']
+    # datasets = ['random-xs']
     for track in tracks:
         for dataset_name in datasets:
             print(f"Looking at track:{track}, dataset:{dataset_name}")

--- a/neurips23/streaming/pinecone/config.yaml
+++ b/neurips23/streaming/pinecone/config.yaml
@@ -1,3 +1,16 @@
+random-xs:
+  pinecone:
+    docker-tag: neurips23-streaming-pinecone
+    module: neurips23.streaming.pinecone.pinecone
+    constructor: pinecone
+    base-args: ["@metric"]
+    run-groups:
+      base:
+        args: |
+          [{"R":32, "L":100, "insert_threads":8, "consolidate_threads":8}]
+        query-args: |
+          [{"Ls":300, "k_1":30, "T":8}]
+
 msturing-30M-clustered:
   pinecone:
     docker-tag: neurips23-streaming-pinecone

--- a/neurips23/streaming/scann/config.yaml
+++ b/neurips23/streaming/scann/config.yaml
@@ -1,12 +1,25 @@
+random-xs:
+  scann:
+    docker-tag: neurips23-streaming-scann
+    module: neurips23.streaming.scann.scann
+    constructor: Scann
+    base-args: ["@metric"]
+    run-groups:
+      base:
+        args: |
+          [{ "tree_size": 5000, "leaves_to_search": 700, "reorder": 317}]
+        query-args: |
+          [{}]
+
 msturing-30M-clustered:
-    scann:
-      docker-tag: neurips23-streaming-scann
-      module: neurips23.streaming.scann.scann
-      constructor: Scann
-      base-args: ["@metric"]
-      run-groups:
-        dynamic4M:
-          args: |
-            [{ "tree_size": 5000, "leaves_to_search": 700, "reorder": 317}]
-          query-args: |
-            [{}]
+  scann:
+    docker-tag: neurips23-streaming-scann
+    module: neurips23.streaming.scann.scann
+    constructor: Scann
+    base-args: ["@metric"]
+    run-groups:
+      dynamic4M:
+        args: |
+          [{ "tree_size": 5000, "leaves_to_search": 700, "reorder": 317}]
+        query-args: |
+          [{}]


### PR DESCRIPTION
（一）算法数据集的默认选项
streaming和congestion下的算法config.yaml中均加入了random-xs相关配置（默认），若特定数据集无配置信息，默认使用random-xs.

（二）自动化runbook迁移至congestion
1. create_dataset.py和run.py均加入两个命令行参数（可选，非必须）：batchsize、eventrate；
2. 针对create_dataset.py：若不输入batchsize、eventrate，则只更新streaming/simple_runbook.yaml；若同时输入batchsize、eventrate，则同时更新streaming/simple_runbook.yaml和congestion/simple_runbook.yaml
3. 针对run.py：若输入batchsize、eventrate，则要求其他命令行参数必须与相关congestion配套，尤其--neurips23track congestion；正常情况下无需输入（因为创建数据集时已经写入两个参数信息）

（三）最终输出结果优化
对应res.csv-congestion.csv文件内容参考如下：数据集名称后记录着两个参数信息
![{54A5141D-301F-4638-B0F1-7A572D3D41C2}](https://github.com/user-attachments/assets/6764b183-ee8c-4d67-90e8-03cad0cdbde1)
